### PR TITLE
Multi-stage build + removing bootnode binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM golang:1.10-alpine
+FROM golang:1.10-alpine as builder
 
 ARG VERSION=43c57c528
 
 RUN apk add --update git vim curl wget gcc g++ bash musl-dev linux-headers
-
 RUN mkdir -p $GOPATH/src/github.com/ethereum && \
     cd $GOPATH/src/github.com/ethereum && \
     git clone https://github.com/ethersphere/go-ethereum && \
@@ -14,12 +13,14 @@ RUN mkdir -p $GOPATH/src/github.com/ethereum && \
     cd $GOPATH/src/github.com/ethereum/go-ethereum && \
     go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm && \
     go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/geth && \
-    go install ./cmd/bootnode && \
-    cp $GOPATH/bin/swarm /swarm && cp $GOPATH/bin/geth /geth && cp $GOPATH/bin/bootnode /bootnode && \
+    cp $GOPATH/bin/swarm /swarm && cp $GOPATH/bin/geth /geth && \
     apk del git go make gcc musl-dev g++ libc-dev && \
     rm -rf $GOPATH && rm -rf /var/cache/apk/*
 
-ADD run.sh /run.sh
-RUN chmod a+x /*.sh
 
+# Release image with the required binaries and scripts
+FROM alpine:3.8
+WORKDIR /
+COPY --from=builder /swarm /geth /
+ADD run.sh /run.sh
 ENTRYPOINT ["/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -o errexit
 set -o pipefail


### PR DESCRIPTION
I've updated the `Dockerfile` to use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/). This way we get rid of unnecessary dependencies on the release image (e.g. the golang compiler)

Additionally I also removed the bootnode binary as I didn't see that it was called from anywhere. Please correct me if I'm wrong.

Image size comparison: 

```
swarm-local-multistage:latest     81.3MB
swarm-local:latest                 615MB
```