### PR TITLE
add run-smoke.sh and build swarm-smoke as part of swarm image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.11-alpine as builder
 
-ARG VERSION=24d727b6d
+ARG VERSION=4aeeecfde
 
 RUN apk add --update git gcc g++ linux-headers
 RUN mkdir -p $GOPATH/src/github.com/ethereum && \
@@ -9,16 +9,18 @@ RUN mkdir -p $GOPATH/src/github.com/ethereum && \
     cd $GOPATH/src/github.com/ethereum/go-ethereum && \
     git checkout ${VERSION} && \
     go get github.com/ethereum/go-ethereum && \
-    go get . && go get ./cmd/geth && go get ./cmd/swarm && \
+    go get . && go get ./cmd/geth && go get ./cmd/swarm && go get ./cmd/swarm/swarm-smoke && \
     cd $GOPATH/src/github.com/ethereum/go-ethereum && \
     go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm && \
     go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/geth && \
-    cp $GOPATH/bin/swarm /swarm && cp $GOPATH/bin/geth /geth
+    go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm/swarm-smoke && \
+    cp $GOPATH/bin/swarm /swarm && cp $GOPATH/bin/geth /geth && cp $GOPATH/bin/swarm-smoke /swarm-smoke
 
 
 # Release image with the required binaries and scripts
 FROM alpine:3.8
 WORKDIR /
-COPY --from=builder /swarm /geth /
+COPY --from=builder /swarm /geth /swarm-smoke /
 ADD run.sh /run.sh
+ADD run-smoke.sh /run-smoke.sh
 ENTRYPOINT ["/run.sh"]

--- a/run-smoke.sh
+++ b/run-smoke.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+/swarm-smoke $@ 2>&1 || true


### PR DESCRIPTION
This is adding the `run-smoke.sh` and `swarm-smoke` binary to the `swarm` images.

For simplicity we keep on image right now, once we start building larger deployments, we might want to split the end image into `swarm`, `geth` and `smoke`.