### PR TITLE
add bzzkey to hosttag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.11-alpine as builder
 
-ARG VERSION=9dc5d1a91
+ARG VERSION=9bc0138de
 
 RUN apk add --update git gcc g++ linux-headers
 RUN mkdir -p $GOPATH/src/github.com/ethereum && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.11-alpine as builder
 
-ARG VERSION=549c16477
+ARG VERSION=6dd6fa17d
 
 RUN apk add --update git gcc g++ linux-headers
 RUN mkdir -p $GOPATH/src/github.com/ethereum && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.11-alpine as builder
 
-ARG VERSION=4aeeecfde
+ARG VERSION=549c16477
 
 RUN apk add --update git gcc g++ linux-headers
 RUN mkdir -p $GOPATH/src/github.com/ethereum && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.11-alpine as builder
 
-ARG VERSION=6dd6fa17d
+ARG VERSION=508f743
 
 RUN apk add --update git gcc g++ linux-headers
 RUN mkdir -p $GOPATH/src/github.com/ethereum && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.11-alpine as builder
 
-ARG VERSION=508f743
+ARG VERSION=ee1b252f7
 
 RUN apk add --update git gcc g++ linux-headers
 RUN mkdir -p $GOPATH/src/github.com/ethereum && \


### PR DESCRIPTION
This PR is attaching the `bzzkey` (a.k.a `queen addr` from Kademlia) next to the container name, so that we can more easily match node ids and bzzkeys.

![screen shot 2019-01-23 at 13 36 40](https://user-images.githubusercontent.com/50459/51607071-f1053200-1f13-11e9-832f-cb40bd9144df.png)
