### PR TITLE
split images and use travis for building and pushing images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: generic
+dist: xenial
+
+before_script:
+  - source .travis/gen-tag.sh
+
+script:
+  - .travis/build.sh
+
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: .travis/push.sh
+    on:
+      all_branches: true
+      condition: $TRAVIS_BRANCH =~ ^anton|rafael|fabio|janos|elad|ferenc|gluk256|louis|viktor$
+  - provider: script
+    skip_cleanup: true
+    script: .travis/push.sh
+    on:
+      tags: true

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -xe
+docker build -t "ethdevops/swarm:$DOCKER_TAG" --target swarm .
+docker build -t "ethdevops/swarm-smoke:$DOCKER_TAG" --target swarm-smoke .

--- a/.travis/gen-tag.sh
+++ b/.travis/gen-tag.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -xe
+export DOCKER_TAG="$TRAVIS_BRANCH"
+if [ "$TRAVIS_BRANCH" == "master" ]; then
+  export DOCKER_TAG="latest"
+fi
+if [[ -n "$TRAVIS_TAG" ]] ; then
+  export DOCKER_TAG="$TRAVIS_TAG"
+fi

--- a/.travis/push.sh
+++ b/.travis/push.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+docker push "ethdevops/swarm:$DOCKER_TAG"
+docker push "ethdevops/swarm-smoke:$DOCKER_TAG"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,19 +8,19 @@ RUN mkdir -p $GOPATH/src/github.com/ethereum && \
     git clone https://github.com/ethersphere/go-ethereum && \
     cd $GOPATH/src/github.com/ethereum/go-ethereum && \
     git checkout ${VERSION} && \
-    go get github.com/ethereum/go-ethereum && \
-    go get . && go get ./cmd/geth && go get ./cmd/swarm && go get ./cmd/swarm/swarm-smoke && \
-    cd $GOPATH/src/github.com/ethereum/go-ethereum && \
     go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm && \
     go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/geth && \
-    go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm/swarm-smoke && \
-    cp $GOPATH/bin/swarm /swarm && cp $GOPATH/bin/geth /geth && cp $GOPATH/bin/swarm-smoke /swarm-smoke
+    go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm/swarm-smoke
 
 
-# Release image with the required binaries and scripts
-FROM alpine:3.8
+FROM alpine:3.8 as swarm-smoke
 WORKDIR /
-COPY --from=builder /swarm /geth /swarm-smoke /
-ADD run.sh /run.sh
+COPY --from=builder /go/bin/swarm-smoke /
 ADD run-smoke.sh /run-smoke.sh
+ENTRYPOINT ["/run-smoke.sh"]
+
+FROM alpine:3.8 as swarm
+WORKDIR /
+COPY --from=builder /go/bin/swarm /go/bin/geth /
+ADD run.sh /run.sh
 ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
This change is required so that we're consistent with our `edge` image: https://github.com/ethersphere/go-ethereum/blob/master/swarm/docker/Dockerfile

Previously we were using dockerhub to build the docker images. This doesn't work anymore becoes it doesn't support using the `--target` flag to target specific image on a multi-stage build. 

Due to this reason I'm moving the build and push to Travis. 

Ideally it would be great to not have these two Dockerfiles in separate repos. But for now we'll keep it like this. 